### PR TITLE
Revert "Add Table of Contents"

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,33 +40,3 @@ h2 {
 h3 {
   font-size: 1.7em;
 }
-
-#toc, .toc {
-  padding-right: 10px;
-  position: fixed;
-  font-size: 95%;
-  line-height: 2em;
-}
-
-.toc a {
-  color: #767676;
-  padding-left: 10px;
-}
-
-.toc ul {
-  list-style-type: none;
-  padding-left: 1%;
-}
-
-.toc li{
-  border-left: 2px solid #fff;
-}
-
-.toc li:hover{
-  text-decoration: none;
-  border-left: 2px solid #23527c;
-}
-
-.toc a:hover{
-  text-decoration: none;
-}

--- a/index.html
+++ b/index.html
@@ -21,16 +21,6 @@
         </div>
     </div>
     <br>
-
-    <div id="toc" class="toc visible-lg">
-      <ul>
-        <li><a href="#Getting_Started">Getting Started</a></li>
-        <li><a href="#Contributing">Contributing</a></li>
-        <li><a href="#Communication">Communication</a></li>
-        <li><a href="#Conduct">Conduct</a></li>
-      </ul>
-    </div>
-
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
             <p class='info'>Written in Mozilla's new systems programming language,
@@ -64,27 +54,9 @@
         </div>
 
     </div>
-
-    <div class="row">
-      <div class='col-sm-offset-2 col-sm-8'>
-        <div id="toc" class="toc">
-          <div id="toctitle">
-            <h2 class="text-center">Contents</h2>
-          </div>
-          <ul>
-            <li class="toclevel-1"><a href="#Getting_Started">Getting Started</a></li>
-            <li class="toclevel-1"><a href="#Contributing">Contributing</a></li>
-            <li class="toclevel-1"><a href="#Communication">Communication</a></li>
-            <li class="toclevel-1"><a href="#Conduct">Conduct</a></li>
-
-          </ul>
-        </div>
-      </div>
-    </div>
-
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8'>
-            <h2 class='header' id="Getting_Started">Getting Started</h2>
+            <h2 class='header'>Getting Started</h2>
             <h3>Prerequisites</h3>
             <p>
                 You can find what you need to install on your particular system
@@ -130,7 +102,7 @@ cd servo
 
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8'>
-            <h2 class='header' id="Contributing">Contributing</h2>
+            <h2 class='header'>Contributing</h2>
 
             <p id='contributing'>The Servo Project encourages contributions from
                 experienced and new developers alike.
@@ -196,7 +168,7 @@ cd servo
 
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8'>
-            <h2 class='header' id="Communication">Communication</h2>
+            <h2 class='header'>Communication</h2>
 
             <p>
                 Servo contributors frequent the #servo channel on
@@ -210,7 +182,7 @@ cd servo
 
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8'>
-            <h2 class='header' id="Conduct">Conduct</h2>
+            <h2 class='header'>Conduct</h2>
 
             <p>
                 We follow the


### PR DESCRIPTION
Reverts servo/servo.org#19

There's a weird floating "Contents:" at the bottom of the page in both Firefox and Chrome after merging #19.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/21)

<!-- Reviewable:end -->
