### PR TITLE
eliminate spurious space in Rust link

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
             <p class='info'>Sponsored by Mozilla and written in the new systems
-                programming language <a href='http://www.rust-lang.org'>Rust
-                </a>, the Servo project aims to achieve better parallelism,
+                programming language <a href='http://www.rust-lang.org'>Rust</a>,
+                the Servo project aims to achieve better parallelism,
                 security, modularity, and performance.
             </p>
         </div>


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/28)

<!-- Reviewable:end -->
