### PR TITLE
Convert `http` links to `https` links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[servo.org](http://servo.org/)
+[servo.org](https://servo.org/)
 ==============================
 
 The source for the Servo website, not including subdomains.

--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
     <div class='row'>
         <div class='col-sm-offset-2 col-sm-8 col-lg-4'>
             <p class='info'>Sponsored by Mozilla and written in the new systems
-                programming language <a href='http://www.rust-lang.org'>Rust</a>,
+                programming language <a href='https://www.rust-lang.org'>Rust</a>,
                 the Servo project aims to achieve better parallelism,
                 security, modularity, and performance.
             </p>
 	    <div class='row'>
 	      <div class='col-sm-12'>
-		<a class='btn btn-lg btn-primary center-block' href="http://download.servo.org">Download Servo nightly build</a>
+		<a class='btn btn-lg btn-primary center-block' href="https://download.servo.org">Download Servo nightly build</a>
 		<br><br>
 	      </div>
 	    </div>
@@ -169,7 +169,7 @@ cd servo
             </ul>
 
             <a class='btn btn-primary btn-large' role='button'
-               href='http://servo.github.io/servo-starters'>Start Contributing</a>
+               href='https://starters.servo.org/'>Start Contributing</a>
         </div>
     </div>
 
@@ -193,7 +193,7 @@ cd servo
 
             <p>
                 We follow the
-                <a href="http://www.rust-lang.org/conduct.html">Rust Code of Conduct.</a>
+                <a href="https://www.rust-lang.org/conduct.html">Rust Code of Conduct.</a>
             </p>
 
         </div>
@@ -210,7 +210,7 @@ cd servo
                     <a href='https://github.com/servo/servo/wiki/Roadmap'>Follow Servo's Roadmap</a>
                 </div>
                 <div class='col-md-3'>
-                    <a href="http://blog.servo.org/">Read the Servo blog</a>
+                    <a href="https://blog.servo.org/">Read the Servo blog</a>
                 </div>
                 <div class='col-md-3'>
                     <p class='text-muted'>#servo on irc.mozilla.org</p>

--- a/starters/index.html
+++ b/starters/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <title>Servo, the parallel browser engine</title>
-<meta http-equiv=refresh content="0;url=http://servo.github.io/servo-starters/">
+<meta http-equiv=refresh content="0;url=https://starters.servo.org">
 
-Take a look at our issues that are <a href="http://servo.github.io/servo-starters/">recommended for newcomers!</a>
+Take a look at our issues that are <a href="https://starters.servo.org/">recommended for newcomers!</a>


### PR DESCRIPTION
Several `http` href links were converted to `https`. All of these links
are to servo.org and subdomains, or to rust-lang.org, which support
https.

The links to the starters page were updated to
`starters.servo.org`.

The exceptions are urls in license files, and two urls in bhtml-newtab:
`arstechnica.com`, and the jquery cdn. The last one was exluded from
this PR, because it modifies something in the browser, and should be
replaced with care (and testing?)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/34)

<!-- Reviewable:end -->
