### PR TITLE
Update the platforms Servo currently supports

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                     community, from individual contributors to companies such as Mozilla and
                     Samsung.</p>
 
-                <p> Servo currently supports Linux, OSX, Windows, Android, and Gonk (Firefox OS).</p>
+                <p> Servo currently supports Linux, macOS, Windows, and Android.</p>
 
             </div>
         </div>


### PR DESCRIPTION
Apple rebranded OS X to macOS; the gonk port was removed in servo/servo#11474.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/35)

<!-- Reviewable:end -->
