### PR TITLE
index.html: fix broken prerequisites link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <h3>Prerequisites</h3>
         <p>
           You can find what you need to install on your particular system
-          <a href="https://github.com/servo/servo#prerequisites"> on our github</a>.
+          <a href="https://github.com/servo/servo#setting-up-your-environment"> on our github</a>.
         </p>
 
         <h3>Building</h3>


### PR DESCRIPTION
The anchor ref on the old link was busted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/42)
<!-- Reviewable:end -->
