### PR TITLE
Capitalize blog link to match download page

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@ cd servo
           <a href='https://github.com/servo/servo/wiki/Roadmap'>Follow Servo's Roadmap</a>
         </div>
         <div class='col-md-3'>
-          <a href="https://blog.servo.org/">Read the Servo blog</a>
+          <a href="https://blog.servo.org/">Read the Servo Blog</a>
         </div>
         <div class='col-md-3'>
           <p class='text-muted'>#servo on irc.mozilla.org</p>


### PR DESCRIPTION
I edited this on the download page in https://github.com/servo/download.servo.org/pull/39 and forgot that the link on the homepage needed to be changed as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/53)
<!-- Reviewable:end -->
