### PR TITLE
Update URL to Rust Code of Conduct

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@ cd servo
 
         <p>
           We follow the
-          <a href="https://www.rust-lang.org/conduct.html">Rust Code of Conduct.</a>
+          <a href="https://www.rust-lang.org/policies/code-of-conduct">Rust Code of Conduct.</a>
         </p>
 
       </div>


### PR DESCRIPTION
CoC is moved to a new URL after Rust's homepage redesign. The old URL results in a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/68)
<!-- Reviewable:end -->
