### PR TITLE
Use the r105 version of three.js, which doesn't use modules

### DIFF
--- a/ml-home/index.html
+++ b/ml-home/index.html
@@ -134,17 +134,17 @@
       <div class="tile-title">30k Particles</div>
     </a>
     <a class="tile"
-       href="https://threejs.org/examples/#webgl_animation_cloth">
+       href="https://rawcdn.githack.com/mrdoob/three.js/r105/examples/#webgl_animation_cloth">
       <div class="tile-image cloth"></div>
       <div class="tile-title">WebGL Cloth</div>
     </a>
     <a class="tile"
-       href="https://threejs.org/examples/#webgl_materials_cubemap_balls_refraction">
+       href="https://rawcdn.githack.com/mrdoob/three.js/r105/examples/#webgl_materials_cubemap_balls_refraction">
       <div class="tile-image refraction"></div>
       <div class="tile-title">WebGL Refraction</div>
     </a>
     <a class="tile"
-       href="https://threejs.org/examples/#webgl_decals">
+       href="https://rawcdn.githack.com/mrdoob/three.js/r105/examples/#webgl_decals">
       <div class="tile-image decals"></div>
       <div class="tile-title">WebGL Decals</div>
     </a>


### PR DESCRIPTION
This is a workaround for https://github.com/servo/servo/issues/23954.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo.org/74)
<!-- Reviewable:end -->
