### PR TITLE
Add debug loader for bbjs demos

### DIFF
--- a/hl-home/bbjs/debug.html
+++ b/hl-home/bbjs/debug.html
@@ -1,0 +1,55 @@
+﻿<!DOCTYPE html>
+<html>
+
+    <head>
+        <title>Babylon.js Playground</title>
+        <link rel="shortcut icon" href="./www.babylonjs.com/img/favicon/favicon.ico">
+        <meta name="theme-color" content="#ffffff">
+        <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
+
+        <script src="./code.jquery.com/pep/0.4.2/pep.min.js"></script>
+        <!-- DatGUI -->
+        <script src="./cdnjs.cloudflare.com/ajax/libs/dat-gui/0.6.2/dat.gui.min.js"></script>
+        <!-- Babylon.js -->
+        <script src="./preview.babylonjs.com/ammo.js"></script>
+        <script src="./preview.babylonjs.com/recast.js"></script>
+        <script src="./preview.babylonjs.com/cannon.js"></script>
+        <script src="./preview.babylonjs.com/Oimo.js"></script>
+        <script src="./preview.babylonjs.com/libktx.js"></script>
+        <script src="./preview.babylonjs.com/babylon.max.js"></script>
+        <script src="./preview.babylonjs.com/gui/babylon.gui.min.js"></script>
+        <script src="./preview.babylonjs.com/inspector/babylon.inspector.bundle.js"></script>
+        <script src="./preview.babylonjs.com/nodeEditor/babylon.nodeEditor.js"></script>
+        <script src="./preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
+        <script src="./preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js">
+        </script>
+        <script src="./preview.babylonjs.com/postProcessesLibrary/babylonjs.postProcess.min.js"></script>
+        <script src="./preview.babylonjs.com/loaders/babylonjs.loaders.js"></script>
+
+        <!-- Extensions -->
+        <script
+            src="./rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js"
+            async>
+        </script>
+        <script
+            src="./rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js"
+            async></script>
+
+        <!-- Scene Manager -->
+        <script
+            src="./rawcdn.githack.com/MackeyK24/MackeyK24.github.io/14fda491c50cfca6d3e2f6cbc5e6afe22cc455d6/toolkit/babylon.manager.js">
+        </script>
+        <script
+            src="./rawcdn.githack.com/MackeyK24/MackeyK24.github.io/14fda491c50cfca6d3e2f6cbc5e6afe22cc455d6/toolkit/babylon.navmesh.js">
+        </script>
+        <link href="./playground.babylonjs.com/css/frame.css" rel="stylesheet" />
+    </head>
+
+    <body>
+        <!-- Override frame style -->
+        <canvas touch-action="none" id="renderCanvas" tabindex="1" style="height: 100%"></canvas>
+        <script src="./code.jquery.com/jquery.min.js"></script>
+        <script src="./playground.babylonjs.com/js/loader.js"></script>
+    </body>
+
+</html>


### PR DESCRIPTION
This includes a unminified version of babylonjs. It will make our life easier for debugging the demos.

For example, to debug the drum demo: https://servo.org/hl-home/bbjs/debug.html#drums.js

This loads the unminified version of bbjs.